### PR TITLE
Update src/2013-01-16-timing-normal-rngs.Rmd

### DIFF
--- a/src/2013-01-16-timing-normal-rngs.Rmd
+++ b/src/2013-01-16-timing-normal-rngs.Rmd
@@ -84,6 +84,8 @@ the C++11 extensions:
 
 ```{r}
 Sys.setenv("PKG_CXXFLAGS"="-std=c++11")
+# or
+# Sys.setenv("PKG_CXXFLAGS"="-std=c++0x")
 ```
 
 That way, we can compile this code:


### PR DESCRIPTION
Add variant of the std designation for (I think) some earlier versions of compilers (g++ < 4.7)
