### PR TITLE
Link to git hub context page, not raw source page.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: layout
  <h2>{{ page.title }}</h2>
  <p class="muted" style="margin-bottom: 1.2em; margin-top: .5em;">
     {{ page.author }} &mdash; {{ page.date | date: "%b %e, %Y" }} | 
-    <a href="https://raw.github.com/jjallaire/rcpp-gallery/gh-pages/src/{{ page.src }}">source</a>
+    <a href="https://github.com/jjallaire/rcpp-gallery/blob/gh-pages/src/{{ page.src }}">source</a>
  </p>
    
  {{ content }}


### PR DESCRIPTION
Better facilitates feedback and forking.  If the viewer wants the 
raw source, there's a button for that too.
