### PR TITLE
dmvnorm_arma Updated based on Peter Rossi's comments

### DIFF
--- a/src/2013-07-13-dmvnorm_arma.Rmd
+++ b/src/2013-07-13-dmvnorm_arma.Rmd
@@ -1,9 +1,9 @@
 ---
-title: Faster Multivariate Normal densities with RcppArmadillo and openmp
-author: Nino Hardt, Dicko Ahmadou
+title: Faster Multivariate Normal densities with RcppArmadillo and OpenMP
+author: Nino Hardt, Dicko Ahmadou, Peter Rossi
 license: GPL (>= 2)
-tags: RcppArmadillo, openmp
-summary: Fast implementation of Multivariate Normal density using RcppArmadillo and openmp.
+tags: RcppArmadillo, OpenMP
+summary: Fast implementation of Multivariate Normal density using RcppArmadillo and OpenMP.
 ---
 
 The Multivariate Normal density function is used frequently
@@ -11,137 +11,247 @@ in a number of problems. Especially for MCMC problems, fast
 evaluation is important. Multivariate Normal Likelihoods, 
 Priors and mixtures of Multivariate Normals require numerous 
 evaluations, thus speed of computation is vital. 
-We show a twofold increase in speed by using RcppArmadillo, 
-and some extra gain by using openmp.
-
-This project is based on the following [StackOverflow post](http://stackoverflow.com/questions/17617618/dmvnorm-mvn-density-rcpparmadillo-implementation-slower-than-r-package-includi). 
+We show daramatic increases in speed by using efficient algorithms,
+RcppArmadillo, and some extra gain by using OpenMP.
+The code is based on the latest version of RcppArmadillo (0.3.910.0).
 
 Loading necessary packages:
+```{r, echo=TRUE, include=FALSE,}
+  libs=c("mvtnorm","inline","Rcpp","RcppArmadillo","rbenchmark","bayesm","parallel","microbenchmark")
+  if( sum(!(libs %in% .packages(all.available = TRUE)))>0){
+      install.packages(libs[!(libs %in% .packages(all.available = TRUE))])
+  }
+  
+  for(i in 1:length(libs)) {
+      library(libs[i],character.only = TRUE,quietly=TRUE)
+  }
+```
+
+
+While the 'dmvnorm' function from the 'mvtnorm' package is quite popular,
+in fact 'lndMvn' from the bayesm package is much faster. Its matrix-equivalent
+is 'dMvn', which is used internally by the mixture of normals model 
+implementation in 'bayesm'.
+
 ```{r}
-libs=c("mvtnorm","inline","Rcpp","RcppArmadillo","rbenchmark","bayesm","parallel")
-if( sum(!(libs %in% .packages(all.available = TRUE)))>0){
-    install.packages(libs[!(libs %in% .packages(all.available = TRUE))])
-}
-
-for(i in 1:length(libs)) {
-    library(libs[i],character.only = TRUE,quietly=TRUE)
-}
+  dMvn=function(X,mu,Sigma)
+  {
+    k=ncol(X)
+    rooti=backsolve(chol(Sigma),diag(k))
+    quads=colSums((crossprod(rooti,(t(X)-mu)))^2)
+    return(exp(-(k/2)*log(2*pi) + sum(log(diag(rooti))) - .5*quads))
+  }
 ```
 
 
-First, we show the RcppArmadillo implementation without openmp.
+Translating this approach into RcppArmadillo, we precompute most parts
+before running a loop instead of vectorized code. 
+The loop can easily be parallelized, and the code is easy to read and 
+manipulate.
+
 ```{r, engine='Rcpp'}
-#include <RcppArmadillo.h>
-#include <Rcpp.h>
-
-// [[Rcpp::depends("RcppArmadillo")]]
-// [[Rcpp::export]]
-arma::vec Mahalanobis(arma::mat x, arma::rowvec center, arma::mat cov){
+  #include <RcppArmadillo.h>
+  
+  // [[Rcpp::depends("RcppArmadillo")]]
+  // [[Rcpp::export]]
+  arma::vec dmvnrm_arma( arma::mat x,  
+                         arma::rowvec mean,  
+                         arma::mat sigma, 
+                         bool logd = false ){ 
     int n = x.n_rows;
-    arma::mat x_cen;
-    x_cen.copy_size(x);
-    for (int i=0; i < n; i++) {
-        x_cen.row(i) = x.row(i) - center;
-    }
-    return sum((x_cen * cov.i()) % x_cen, 1);    
-}
-
-// [[Rcpp::export]]
-arma::vec dmvnorm_arma ( arma::mat x,  arma::rowvec mean,  arma::mat sigma, bool log = false){ 
-    arma::vec distval = Mahalanobis(x,  mean, sigma);
-    double logdet = sum(arma::log(arma::eig_sym(sigma)));
-    double log2pi = std::log(2.0 * M_PI);
-    arma::vec logretval = -( (x.n_cols * log2pi + logdet + distval)/2  ) ;
+    int xdim=x.n_cols;
+    arma::vec out(n);
+    arma::mat rooti(n,xdim);  
+    rooti= arma::trans(arma::inv(trimatu(arma::chol(sigma))));
+    double rootisum = arma::sum(log(rooti.diag()));
+    double constants = -(xdim/2) * log(2 * M_PI);
     
-    if(log){ 
-      return(logretval);
-    }else { 
-      return(exp(logretval));
-    }
-}
+      for (int i=0; i < n; i++) {
+          arma::vec z = rooti * arma::trans( x.row(i) - mean) ;    
+          out(i)      = constants - 0.5 * arma::sum(z%z) + rootisum;     
+      }  
+      
+      if(logd==false){
+          out=exp(out);
+        }
+    return(out);
+  }
 ```
+
+
+
+Additionally, we can make use of the openMP library to use multiple 
+cores. For the OpenMP implementation, we need to enable OpenMP support. 
+One way of doing so is by adding the required compiler and linker 
+flags as follows:
+
+```{r}
+  Sys.setenv("PKG_CXXFLAGS"="-fopenmp")
+  Sys.setenv("PKG_LIBS"="-fopenmp")
+```
+
+
+
+We also need to set the number of cores to be used before running the
+compiled functions. One way is to use 'detectCores()' from the 'parallels'
+package.
+
+```{r}
+  cores=detectCores()
+```
+
+
+
+Only two additional lines are needed to enable multicore processing. 
+In this example, a dynamic schedule is used for OpenMP. 
+A static schedule might be faster in some cases. However,this is 
+left to further experimentation.
+
+
+```{r, engine='Rcpp'}
+  #include <RcppArmadillo.h>
+  #include <omp.h>
+
+  // [[Rcpp::depends("RcppArmadillo")]]
+  // [[Rcpp::export]]
+  arma::vec dmvnrm_arma_mc(arma::mat x,  
+                           arma::rowvec mean,  
+                           arma::mat sigma, 
+                           bool logd = false,
+                           int cores = 1){ 
+    omp_set_num_threads( cores );
+    int n = x.n_rows;
+    int xdim=x.n_cols;
+    arma::vec out(n);
+    arma::mat rooti(n,xdim);  
+    rooti= arma::trans(arma::inv(trimatu(arma::chol(sigma))));
+    double rootisum = arma::sum(log(rooti.diag()));
+    double constants = -(xdim/2) * log(2 * M_PI);
+    #pragma omp parallel for schedule(dynamic) 
+      for (int i=0; i < n; i++) {
+          arma::vec z = rooti * arma::trans( x.row(i) - mean) ;    
+          out(i)      = constants - 0.5 * arma::sum(z%z) + rootisum;     
+      }  
+      
+      if(logd==false){
+          out=exp(out);
+        }
+    return(out);
+  }
+```
+
+
+
+Likewise, it is easy to translate 'dmvnorm' from the 'mvtnorm' 
+package into Rcpp:
+
+```{r, engine='Rcpp'}
+  #include <RcppArmadillo.h>
+  
+  // [[Rcpp::depends("RcppArmadillo")]]
+  // [[Rcpp::export]]
+  arma::vec Mahalanobis(arma::mat x, arma::rowvec center, arma::mat cov){
+      int n = x.n_rows;
+      arma::mat x_cen;
+      x_cen.copy_size(x);
+      for (int i=0; i < n; i++) {
+          x_cen.row(i) = x.row(i) - center;
+      }
+      return sum((x_cen * cov.i()) % x_cen, 1);    
+  }
+  
+  // [[Rcpp::export]]
+  arma::vec dmvnorm_arma( arma::mat x,  arma::rowvec mean,  arma::mat sigma, bool log = false){ 
+      arma::vec distval = Mahalanobis(x,  mean, sigma);
+      double logdet = sum(arma::log(arma::eig_sym(sigma)));
+      double log2pi = std::log(2.0 * M_PI);
+      arma::vec logretval = -( (x.n_cols * log2pi + logdet + distval)/2  ) ;
+      
+      if(log){ 
+        return(logretval);
+      }else { 
+        return(exp(logretval));
+      }
+  }
+```
+
+
+
+This code can also make use of the openMP framework:
+
+```{r, engine='Rcpp'}
+  #include <RcppArmadillo.h>
+  #include <omp.h>
+  
+  // [[Rcpp::depends("RcppArmadillo")]]
+  // [[Rcpp::export]]
+  arma::vec Mahalanobis_mc(arma::mat x, arma::rowvec center, arma::mat cov, int cores=1){
+      omp_set_num_threads(cores);
+      int n = x.n_rows;
+      arma::mat x_cen;
+      x_cen.copy_size(x);
+      #pragma omp parallel for schedule(dynamic)   
+          for (int i=0; i < n; i++) {
+              x_cen.row(i) = x.row(i) - center;
+          }
+      return sum((x_cen * cov.i()) % x_cen, 1);    
+  }
+  
+  // [[Rcpp::export]]
+  arma::vec dmvnorm_arma_mc ( arma::mat x,  arma::rowvec mean,  arma::mat sigma, bool log = false, int cores=1){ 
+      arma::vec distval = Mahalanobis_mc(x,  mean, sigma, cores);
+      double logdet = sum(arma::log(arma::eig_sym(sigma)));
+      double log2pi = std::log(2.0 * M_PI);
+      arma::vec logretval = -( (x.n_cols * log2pi + logdet + distval)/2  ) ;
+      
+      if(log){ 
+          return(logretval);
+      }else { 
+          return(exp(logretval));
+      }
+  }
+```
+
+
 
 Now we simulate some data for benchmarking:
 ```{r}
-#simulate data
-    set.seed(3242352532)
-    sigma = rwishart(10,diag(4))$IW
-    means = rnorm(4)
-    X     = rmvnorm(500000, means, sigma)
-```
-
-And run benchmark:
-```{r}
-#benchmark
-benchmark( mvtnorm::dmvnorm(X,means,sigma), 
-           dmvnorm_arma(X,means,sigma) , order="relative", replications=50    )
+    set.seed(123)
+    sigma = rwishart(10,diag(8))$IW
+    means = rnorm(8)
+    X     = rmvnorm(900000, means, sigma)
 ```
 
 
-For the openmp implementation, we need to run the following 
-commands under windows:
-```{r}
-if(Sys.info()['sysname']=="Windows"){
-    Sys.setenv("PKG_CXXFLAGS"="-fopenmp")
-    Sys.setenv("PKG_LIBS"="-fopenmp")
-}
-```
 
-The source code only changes slightly. I have chosen a dynamic 
-schedule for openmp, although a static schedule might be faster 
-in some cases. This is left to further experimentation.
-```{r, engine='Rcpp'}
-#include <RcppArmadillo.h>
-#include <Rcpp.h>
-#include <omp.h>
-
-// [[Rcpp::depends("RcppArmadillo")]]
-// [[Rcpp::export]]
-arma::vec Mahalanobis_mc(arma::mat x, arma::rowvec center, arma::mat cov, int cores=1){
-    omp_set_num_threads( cores );
-    int n = x.n_rows;
-    arma::mat x_cen;
-    x_cen.copy_size(x);
-    #pragma omp parallel for schedule(dynamic)   
-        for (int i=0; i < n; i++) {
-            x_cen.row(i) = x.row(i) - center;
-        }
-    return sum((x_cen * cov.i()) % x_cen, 1);    
-}
-
-// [[Rcpp::export]]
-arma::vec dmvnorm_arma_mc ( arma::mat x,  arma::rowvec mean,  arma::mat sigma, bool log = false, int cores=1){ 
-    arma::vec distval = Mahalanobis_mc(x,  mean, sigma, cores);
-    double logdet = sum(arma::log(arma::eig_sym(sigma)));
-    double log2pi = std::log(2.0 * M_PI);
-    arma::vec logretval = -( (x.n_cols * log2pi + logdet + distval)/2  ) ;
-    
-    if(log){ 
-        return(logretval);
-    }else { 
-        return(exp(logretval));
-    }
-}
-```
-
-
-We need to set the number of cores to be used. 
-```{r}
-    cores=detectCores()
-```
-
-
-Now we are ready to benchmark again. The speed gain of 
-the openmp version is not big, but noticable. 
+And run the benchmark:
 
 ```{r}
-benchmark( mvtnorm::dmvnorm(X,means,sigma), 
-           dmvnorm_arma(X,means,sigma) ,
-           dmvnorm_arma_mc(X,means,sigma, cores), order="relative", replications=50    )
+  print(paste0("Using ",cores," cores for _mc versions"))
+  benchmark( mvtnorm::dmvnorm(X,means,sigma,log=F), 
+             dmvnorm_arma(X,means,sigma,F) , 
+             dmvnorm_arma_mc(X,means,sigma,F, cores) , 
+             dmvnrm_arma(X,means,sigma,F) , 
+             dmvnrm_arma_mc(X,means,sigma,F, cores) , 
+             dMvn(X,means,sigma),
+             order="relative", replications=50 )[,1:4]
 ```
+
+
+
+Lastly, we show that the functions yield the same results:
+
+```{r}
+  plot( mvtnorm::dmvnorm(X[1:200,],means,sigma,log=F), dmvnorm_arma(X[1:200,],means,sigma,F)); abline(0,1)  
+  plot( mvtnorm::dmvnorm(X[1:200,],means,sigma,log=F), dmvnrm_arma(X[1:200,],means,sigma,F) ); abline(0,1)  
+  plot( mvtnorm::dmvnorm(X[1:200,],means,sigma,log=F), dMvn(X[1:200,],means,sigma) ); abline(0,1)  
+```
+
 
 The use of RcppArmadillo brings about a significant increase 
-in speed. The addition of openmp leads to only little 
-additional performance. The largest share of the increase 
-in speed is due to faster computation of the Mahalanobis distance, 
-which is used to compute the Multivariate Normal density.
+in speed. The addition of OpenMP leads to only little 
+additional performance. 
+This example also illustrates that Rcpp does not completely
+substitute the need to look for faster algorithms. Basing the
+code of 'lndMvn' instead of 'dmvnorm' leads to a significantly
+faster function.


### PR DESCRIPTION
New function dmvnrm_arma is more efficient
issue #1 For some reason, dmvnorm_arma_mc is slower than dmvnorm_arma
but dmvnrm_arma_mc is faster than dmvnrm_arma
issue #2 Sometimes bogus compilation warning appears Line 1 attempt to
free a non-heap object ‘BB’ [enabled by default]
