### PR TITLE
let me maintain the source hook for Jekyll, and you only modify the output hooks

### DIFF
--- a/_scripts/knit.sh
+++ b/_scripts/knit.sh
@@ -316,14 +316,8 @@ doxygenChunkToRmd <- function(chunk, frontMatter) {
 
 
 # adaption of knitr::render_jekyll
-renderJekyll <- function(extra = '') {
-  knitr::render_markdown(TRUE)
-  hook.r = function(x, options) {
-      stringr::str_c('\n\n{% highlight ', tolower(options$engine), 
-                     if (extra != '') ' ', extra, ' %}\n',
-                    x, 
-                    '{% endhighlight %}\n\n')
-  }
+renderJekyll <- function(...) {
+  knitr::render_jekyll(...)
   hook.t = function(x, options) {
     stringr::str_c('\n\n<pre class="output">\n', 
                    knitr:::escape_html(x), 
@@ -335,7 +329,7 @@ renderJekyll <- function(extra = '') {
     else 
       hook.t(x, options)
   } 
-  knitr::knit_hooks$set(source = hook.r, output = hook.o, warning = hook.t,
+  knitr::knit_hooks$set(output = hook.o, warning = hook.t,
                         error = hook.t, message = hook.t)
 }
 


### PR DESCRIPTION
there was a change to the source hook in knitr v1.4.1: the source code (denoted by the argument `x`) can be a character vector that is not concatenated into a single string; the current version of `render_jekyll()` in knitr 1.4.1 does this correctly, but since your `hook.r` is not synced to mine, the current source code rendering becomes problematic

now I'm just using `render_jekyll()` to keep everything update with knitr, and you only need to maintain the output hooks `hook.o` and `hook.t`; hopefully this fixes the problem, and you no longer need to wrap R code into `{...}`
