### PR TITLE
Update 2013-07-13-dmvnorm_arma.Rmd

### DIFF
--- a/src/2013-07-13-dmvnorm_arma.Rmd
+++ b/src/2013-07-13-dmvnorm_arma.Rmd
@@ -65,7 +65,7 @@ arma::vec dmvnrm_arma(arma::mat x,
     
     for (int i=0; i < n; i++) {
         arma::vec z = rooti * arma::trans( x.row(i) - mean) ;    
-        out(i)      = constants - 0.5 * arma::sum(z%z) + rootisum;     
+        out(i)      = constants - 0.5 * arma::sum(z%z) - 0.5*rootisum;     
     }  
       
     if (logd == false) {
@@ -129,7 +129,7 @@ arma::vec dmvnrm_arma_mc(arma::mat x,
     #pragma omp parallel for schedule(static) 
     for (int i=0; i < n; i++) {
         arma::vec z = rooti * arma::trans( x.row(i) - mean) ;    
-        out(i)      = constants - 0.5 * arma::sum(z%z) + rootisum;     
+        out(i)      = constants - 0.5 * arma::sum(z%z) - 0.5*rootisum;     
     }  
       
     if (logd==false) {


### PR DESCRIPTION
Just want to point out that in both dmvnrm_arma and dmvnrm_arma_mc, the rootisum term entered incorrectly. It should be -0.5*rootisum.
