### PR TITLE
Add BH to the Rcpp::depends statement

### DIFF
--- a/src/2013-03-14-using-bigmemory-with-rcpp.Rmd
+++ b/src/2013-03-14-using-bigmemory-with-rcpp.Rmd
@@ -21,7 +21,10 @@ shows.
 // The next line is all it takes to find the bigmemory
 // headers -- thanks to the magic of Rcpp attributes
 
-// [[Rcpp::depends(bigmemory)]]
+// Because bigmemory now accesses Boost headers from the BH package,
+// we need to make sure we do so as well in the Rcpp::depends comment.
+
+// [[Rcpp::depends(BH, bigmemory)]]
 #include <bigmemory/MatrixAccessor.hpp>
 #include <numeric>
 


### PR DESCRIPTION
as bigmemory now links to BH to find its boost headers, rather than packaging them.
