### PR TITLE
modify pattern to contain abs path in xml

### DIFF
--- a/_includes/feed.xml
+++ b/_includes/feed.xml
@@ -6,8 +6,9 @@
 		<atom:link href="{{ site.url }}/{{ feed_file }}" rel="self" type="application/rss+xml" />
 		{% for post in feed_posts limit:20 %}
   		<item>
+          {% capture abspath %}{{ site.url }}{{ post.url }}/../figure/{% endcapture %}
 				<title>{{ post.title }}</title>
-				<description>{{ post.content | xml_escape }}</description>
+				<description>{{ post.content | xml_escape | replace: '../figure/', abspath }}</description>
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<link>{{ site.url }}/{{ post.url }}</link>
 				<guid isPermaLink="true">{{ site.url }}/{{ post.url }}</guid>


### PR DESCRIPTION
- will affect only relative paths in feed.xml and featured.xml containing "../figure" which should be the case iff the path is from a knitr figure

_Note: this is grep output so "_site/featured.xml" is the filename. Characters in the text are converted for XML, but that has nothing to do with this PR. It was already happening._

**Pre-PR XML**

_site/featured.xml:&lt;p&gt;&lt;img src=&quot;../figure/2014-10-23-SIR-and-revolution-unnamed-chunk-9-1.png&quot; title=&quot;plot of chunk unnamed-chunk-9&quot; alt=&quot;plot of chunk unnamed-chunk-9&quot; width=&quot;800px&quot; height=&quot;800px&quot; style=&quot;display: block; margin: auto;&quot; /&gt;&lt;/p&gt;

_site/feed.xml:&lt;p&gt;&lt;img src=&quot;../figure/2014-10-23-SIR-and-revolution-unnamed-chunk-9-1.png&quot; title=&quot;plot of chunk unnamed-chunk-9&quot; alt=&quot;plot of chunk unnamed-chunk-9&quot; width=&quot;800px&quot; height=&quot;800px&quot; style=&quot;display: block; margin: auto;&quot; /&gt;&lt;/p&gt;

**Post-PR XML**

_site/featured.xml:&lt;p&gt;&lt;img src=&quot;http://gallery.rcpp.org/articles/SIR-and-revolution/../figure/2014-10-23-SIR-and-revolution-unnamed-chunk-9-1.png&quot; title=&quot;plot of chunk unnamed-chunk-9&quot; alt=&quot;plot of chunk unnamed-chunk-9&quot; width=&quot;800px&quot; height=&quot;800px&quot; style=&quot;display: block; margin: auto;&quot; /&gt;&lt;/p&gt;

_site/feed.xml:&lt;p&gt;&lt;img src=&quot;http://gallery.rcpp.org/articles/SIR-and-revolution/../figure/2014-10-23-SIR-and-revolution-unnamed-chunk-9-1.png&quot; title=&quot;plot of chunk unnamed-chunk-9&quot; alt=&quot;plot of chunk unnamed-chunk-9&quot; width=&quot;800px&quot; height=&quot;800px&quot; style=&quot;display: block; margin: auto;&quot; /&gt;&lt;/p&gt;
