### PR TITLE
remove RNGScope from gallery articles

### DIFF
--- a/_posts/2012-12-24-random-number-generation.md
+++ b/_posts/2012-12-24-random-number-generation.md
@@ -24,7 +24,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericMatrix rngCpp(const int N) {
-  RNGScope scope;		// ensure RNG gets set/reset
   NumericMatrix X(N, 4);
   X(_, 0) = runif(N);
   X(_, 1) = rnorm(N);
@@ -98,7 +97,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rngCppScalar() {
-  RNGScope scope;		// ensure RNG gets set/reset
   NumericVector x(4);
   x[0] = R::runif(0,1);
   x[1] = R::rnorm(0,1);

--- a/_posts/2012-12-26-timing-rngs.md
+++ b/_posts/2012-12-26-timing-rngs.md
@@ -71,7 +71,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rcppNormal(const int N) {
-    RNGScope scope;		// ensure RNG gets set/reset
     return rnorm(N, 0, 1);
 }
 {% endhighlight %}

--- a/_posts/2012-12-30-stl-random-shuffle.md
+++ b/_posts/2012-12-30-stl-random-shuffle.md
@@ -27,8 +27,6 @@ inline int randWrapper(const int n) { return floor(unif_rand()*n); }
 
 // [[Rcpp::export]]
 Rcpp::NumericVector randomShuffle(Rcpp::NumericVector a) {
-    // already added by sourceCpp(), but needed standalone
-    Rcpp::RNGScope scope;             
 
     // clone a into b to leave a alone
     Rcpp::NumericVector b = Rcpp::clone(a);

--- a/_posts/2013-01-16-timing-normal-rngs.md
+++ b/_posts/2013-01-16-timing-normal-rngs.md
@@ -29,7 +29,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rcppNormals(int n) {
-    RNGScope scope;             // also done by sourceCpp()
     return rnorm(n);
 }
 {% endhighlight %}

--- a/_posts/2013-04-12-using-the-Rcpp-based-sample-implementation.md
+++ b/_posts/2013-04-12-using-the-Rcpp-based-sample-implementation.md
@@ -84,7 +84,6 @@ CharacterVector csample_char( CharacterVector x,
                               bool replace, 
                               NumericVector prob = NumericVector::create()
                               ) {
-  RNGScope scope ;
   CharacterVector ret = RcppArmadillo::sample(x, size, replace, prob) ;
   return ret ;
 }
@@ -139,7 +138,6 @@ NumericVector csample_num( NumericVector x,
                            bool replace,
                            NumericVector prob = NumericVector::create()
                            ) {
-  RNGScope scope;
   NumericVector ret = RcppArmadillo::sample(x, size, replace, prob);
   return ret;
 }

--- a/_posts/2013-05-08-an-example-of-using-Rcpp-sample.md
+++ b/_posts/2013-05-08-an-example-of-using-Rcpp-sample.md
@@ -93,9 +93,6 @@ using namespace Rcpp ;
 // [[Rcpp::export]]
 IntegerMatrix cpp_getInts(int samples
                           ) {
-  
-    RNGScope scope;
-  
     int cnt = 0 ;
     IntegerMatrix results(20, samples) ;
     IntegerVector frame = seq_len(50) ;

--- a/_posts/2014-01-04-bayesian-time-series-changepoint.md
+++ b/_posts/2014-01-04-bayesian-time-series-changepoint.md
@@ -167,7 +167,6 @@ NumericVector kprobcpp(NumericVector kposs, NumericVector cusum, double lambda, 
 // [[Rcpp::export]]
 NumericMatrix gibbscpp(int nsim, NumericVector y, double a, double b, double c,
                        double d, NumericVector kposs, NumericVector phi, NumericVector k) {
-    RNGScope scope ;
 
     NumericVector lambda;
     NumericVector pmf;

--- a/src/2012-12-24-random-number-generation.cpp
+++ b/src/2012-12-24-random-number-generation.cpp
@@ -21,7 +21,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericMatrix rngCpp(const int N) {
-  RNGScope scope;		// ensure RNG gets set/reset
   NumericMatrix X(N, 4);
   X(_, 0) = runif(N);
   X(_, 1) = rnorm(N);
@@ -57,7 +56,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rngCppScalar() {
-  RNGScope scope;		// ensure RNG gets set/reset
   NumericVector x(4);
   x[0] = R::runif(0,1);
   x[1] = R::rnorm(0,1);

--- a/src/2012-12-26-timing-rngs.cpp
+++ b/src/2012-12-26-timing-rngs.cpp
@@ -70,7 +70,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rcppNormal(const int N) {
-    RNGScope scope;		// ensure RNG gets set/reset
     return rnorm(N, 0, 1);
 }
 

--- a/src/2012-12-30-stl-random-shuffle.cpp
+++ b/src/2012-12-30-stl-random-shuffle.cpp
@@ -24,8 +24,6 @@ inline int randWrapper(const int n) { return floor(unif_rand()*n); }
 
 // [[Rcpp::export]]
 Rcpp::NumericVector randomShuffle(Rcpp::NumericVector a) {
-    // already added by sourceCpp(), but needed standalone
-    Rcpp::RNGScope scope;             
 
     // clone a into b to leave a alone
     Rcpp::NumericVector b = Rcpp::clone(a);

--- a/src/2013-01-16-timing-normal-rngs.Rmd
+++ b/src/2013-01-16-timing-normal-rngs.Rmd
@@ -26,7 +26,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rcppNormals(int n) {
-    RNGScope scope;             // also done by sourceCpp()
     return rnorm(n);
 }
 ```

--- a/src/2013-04-12-using-the-Rcpp-based-sample-implementation.Rmd
+++ b/src/2013-04-12-using-the-Rcpp-based-sample-implementation.Rmd
@@ -67,7 +67,6 @@ CharacterVector csample_char( CharacterVector x,
                               bool replace, 
                               NumericVector prob = NumericVector::create()
                               ) {
-  RNGScope scope ;
   CharacterVector ret = RcppArmadillo::sample(x, size, replace, prob) ;
   return ret ;
 }
@@ -112,7 +111,6 @@ NumericVector csample_num( NumericVector x,
                            bool replace,
                            NumericVector prob = NumericVector::create()
                            ) {
-  RNGScope scope;
   NumericVector ret = RcppArmadillo::sample(x, size, replace, prob);
   return ret;
 }

--- a/src/2013-05-08-an-example-of-using-Rcpp-sample.Rmd
+++ b/src/2013-05-08-an-example-of-using-Rcpp-sample.Rmd
@@ -63,9 +63,6 @@ using namespace Rcpp ;
 // [[Rcpp::export]]
 IntegerMatrix cpp_getInts(int samples
                           ) {
-  
-    RNGScope scope;
-  
     int cnt = 0 ;
     IntegerMatrix results(20, samples) ;
     IntegerVector frame = seq_len(50) ;

--- a/src/2014-01-04-bayesian-time-series-changepoint.Rmd
+++ b/src/2014-01-04-bayesian-time-series-changepoint.Rmd
@@ -162,7 +162,6 @@ NumericVector kprobcpp(NumericVector kposs, NumericVector cusum, double lambda, 
 // [[Rcpp::export]]
 NumericMatrix gibbscpp(int nsim, NumericVector y, double a, double b, double c,
                        double d, NumericVector kposs, NumericVector phi, NumericVector k) {
-    RNGScope scope ;
 
     NumericVector lambda;
     NumericVector pmf;


### PR DESCRIPTION
We use RNGScope explicitly in a number of places within the Gallery. These particular uses of it are essentially no-ops (due to the counter inside RNGScope) and are there mostly just to illustrate the notion that the RNG is being manipulated.

However, if RNGScope is used in non-attributes code (e.g. in a raw extern "C" SEXP function or with inline) without doing the order of destruction dance (declare the object to be returned before the RNGScope object) then it will lead to crashes during some GC operations (rare but definitely seen in the wild). Therefore I don't think we should illustrate "raw" RNGScope without also illustrating the required GC workaround. For the case of the Gallery which is about showcasing attributes based code I think this would add undesirable extra complexity / verbiage, so I propose eliminating RNGScope from Gallery articles entirely.

@kevinushey @eddelbuettel @romainfrancois  What do you think?
