### PR TITLE
add articles showcasing Boost.SIMD usage

### DIFF
--- a/_posts/2016-02-01-rcppnt2-introduction.md
+++ b/_posts/2016-02-01-rcppnt2-introduction.md
@@ -1,0 +1,134 @@
+---
+title: "Introduction to RcppNT2"
+author: "Kevin Ushey"
+license: GPL (>= 2)
+tags: simd parallel
+summary: Introduction to RcppNT2
+layout: post
+src: 2016-02-01-rcppnt2-introduction.Rmd
+---
+
+Modern CPU processors are built with new, extended
+instruction sets that optimize for certain operations. A
+class of these allow for vectorized operations, called
+Single Instruction / Multiple Data
+([SIMD](https://en.wikipedia.org/wiki/SIMD)) instructions. 
+Although modern compilers will use these instructions when
+possible, they are often unable to reason about whether or
+not a particular block of code can be executed using SIMD
+instructions.
+
+The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+is a collection of header-only C++ libraries that make it 
+possible to explicitly request the use of SIMD instructions 
+when possible, while falling back to regular scalar
+operations when not. **NT<sup>2</sup>** itself is powered
+by [Boost](http://www.boost.org/), alongside two proposed
+Boost libraries -- `Boost.Dispatch`, which provides a
+mechanism for efficient tag-based dispatch for functions,
+and `Boost.SIMD`, which provides a framework for the
+implementation of algorithms that take advantage of SIMD
+instructions. [RcppNT2](http://rcppcore.github.io/RcppNT2/)
+wraps and exposes these libraries for use with `R`.
+
+The primary abstraction that `Boost.SIMD` uses under the 
+hood is the `boost::simd::pack<>` data structure. This item 
+represents a small, contiguous, pack of integral objects 
+(e.g. `double`s), and comes with a host of functions that 
+facilitate the use of SIMD operations on those objects when 
+possible. Although you don't need to know the details to use
+the high-level functionality provided by `Boost.SIMD`, it's
+useful for understanding what happens behind the scenes.
+
+Here's a quick example of how we might compute the sum of 
+elements in a vector, using **NT<sup>2</sup>**.
+
+
+{% highlight cpp %}
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// Define a functor -- a C++ class which defines a templated
+// 'function call' operator -- to perform the addition of 
+// two pieces of data.
+struct add_two {
+  template <typename T>
+  T operator()(const T& lhs, const T& rhs) {
+    return lhs + rhs;
+  }
+};
+
+// [[Rcpp::export]]
+double simd_sum(NumericVector x) {
+  // Pass the functor to 'simdReduce()'. This is an
+  // algorithm provided by RcppNT2, which makes it
+  // easy to apply nt2-style functor definitions
+  // across a range of data.
+  return simdReduce(x.begin(), x.end(), 0.0, add_two());
+}
+{% endhighlight %}
+
+Behind the scenes, `simdReduce()` takes care of iteration 
+over the provided sequence, and ensures that we use optimized SIMD 
+instructions over packs of numbers when possible, and scalar
+instructions when not. By passing a templated functor, 
+`simdReduce()` can automatically choose the correct template
+specialization depending on whether it's working with a pack
+or not. In other words, two template specializations will be
+generated in this case: one with `T = double`, and another
+with `T = boost::simd::pack<double>`.
+
+Let's confirm that this produces the correct output, and run
+a small benchmark.
+
+
+{% highlight r %}
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# generate some data
+data <- rnorm(1024 * 1000)
+
+# verify that it produces the correct sum
+all.equal(simd_sum(data), sum(data))
+{% endhighlight %}
+
+
+
+<pre class="output">
+[1] TRUE
+</pre>
+
+
+
+{% highlight r %}
+# compare results
+library(microbenchmark)
+bm <- microbenchmark(sum(data), simd_sum(data))
+printBm(bm)
+{% endhighlight %}
+
+
+
+<pre class="output">
+           expr     min       lq      mean    median       uq      max
+      sum(data) 894.451 943.4145 1033.5598 1020.5000 1071.327 1429.533
+ simd_sum(data) 280.585 293.6315  316.6797  307.8795  314.429  574.050
+</pre>
+
+We get a noticable gain by taking advantage of SIMD 
+instructions here. However, it's worth noting that we don't
+handle `NA` and `NaN` with the same granularity as `R`.
+
+## Learning More
+
+This article provides just a taste of how RcppNT2 can be used.
+If you're interested in learning more, please check out the
+[RcppNT2 website](http://rcppcore.github.io/RcppNT2/).

--- a/_posts/2016-02-01-rcppnt2-sum.md
+++ b/_posts/2016-02-01-rcppnt2-sum.md
@@ -1,0 +1,182 @@
+---
+title: Using RcppNT2 to Compute the Sum
+author: Kevin Ushey
+license: GPL (>= 2)
+tags: simd parallel
+summary: Demonstrates how to compute the sum using RcppNT2.
+layout: post
+src: 2016-02-01-rcppnt2-sum.cpp
+---
+
+
+## Introduction
+
+The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+collection of header-only C++ libraries that make it
+possible to explicitly request the use of SIMD instructions
+when possible, while falling back to regular scalar
+operations when not. **NT<sup>2</sup>** itself is powered
+by [Boost](http://www.boost.org/), alongside two proposed
+Boost libraries -- `Boost.Dispatch`, which provides a
+mechanism for efficient tag-based dispatch for functions,
+and `Boost.SIMD`, which provides a framework for the
+implementation of algorithms that take advantage of SIMD
+instructions.
+[`RcppNT2`](http://rcppcore.github.io/RcppNT2/) wraps
+and exposes these libraries for use with `R`.
+
+If you haven't already, read the
+[RcppNT2 introduction article]({{ site.baseurl }}/articles/rcppnt2-introduction/)
+to get acquainted with the RcppNT2 package.
+
+## Computing the Sum
+
+First, let's review how we might use `std::accumulate()`
+to sum a vector of numbers. We explicitly pass in the
+`std::plus<double>()` functor, just to make it clear that
+the `std::accumulate()` algorithm expects a binary
+functor when accumulating values.
+
+{% highlight cpp %}
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+double vectorSum(NumericVector x) {
+   return std::accumulate(x.begin(), x.end(), 0.0, std::plus<double>());
+}
+{% endhighlight %}
+
+Now, let's rewrite this to take advantage of RcppNT2.
+There are two main steps required to take advantage of
+RcppNT2 at a high level:
+
+1. Write a functor, with a templated call operator,
+with the implementation written in a
+'`Boost.SIMD`-aware' way;
+
+2. Provide the functor as an argument to the
+appropriate SIMD algorithm.
+
+Let's follow these steps in implementing our SIMD sum.
+
+{% highlight cpp %}
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+struct simd_plus {
+   template <typename T>
+   T operator()(const T& lhs, const T& rhs) {
+      return lhs + rhs;
+   }
+};
+
+// [[Rcpp::export]]
+double vectorSumSimd(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, simd_plus());
+}
+{% endhighlight %}
+
+As you can see, it's quite simple to take advantage of
+`Boost.SIMD`. For very simple operations such as this,
+RcppNT2 provides a number of pre-defined functors,
+which can be accessed in the `RcppParallel::functor`
+namespace. The following is an equivalent way of defining
+the above function:
+
+{% highlight cpp %}
+// [[Rcpp::export]]
+double vectorSumSimdV2(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, functor::plus());
+}
+{% endhighlight %}
+
+Behind the scenes of `simdReduce()`, `Boost.SIMD` will 
+apply your templated functor to 'packs' of values when
+appropriate, and scalar values when not. In other words,
+there are effectively two kinds of template
+specializations being generated behind the scenes: one
+with `T = double`, and one with `T =
+boost::simd::pack<double>`. The use of the packed
+representation is what allows `Boost.SIMD` to ensure 
+vectorized instructions are used and generated.
+`Boost.SIMD` provides a host of functions and operator
+overloads that ensure that optimized instructions are
+used when possible over a packed object, while falling 
+back to 'default' operations for scalar values when not.
+
+Now, let's compare the performance of these two
+implementations.
+
+{% highlight r %}
+library(microbenchmark)
+
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# allocate a large vector
+set.seed(123)
+v <- rnorm(1E6)
+
+# ensure they compute the same values
+stopifnot(all.equal(vectorSum(v), vectorSumSimd(v)))
+
+# compare performance
+bm <- microbenchmark(vectorSum(v), vectorSumSimd(v))
+printBm(bm)
+{% endhighlight %}
+
+
+
+<pre class="output">
+             expr     min       lq     mean   median       uq      max
+     vectorSum(v) 870.894 887.1535 978.7471 987.1810 989.1060 1792.215
+ vectorSumSimd(v) 270.985 283.2315 297.8062 287.6565 298.7115  608.373
+</pre>
+
+Perhaps surprisingly, the RcppNT2 solution is much
+faster -- the gains are similar to what we might have
+seen when computing the sum in parallel. However, we're
+still just using a single core; we're just taking
+advantage of vectorized instructions provided by the CPU.
+In this particular case, on Intel CPUs, `Boost.SIMD` will
+ensure that we are using the `addpd` instruction, which
+is documented in the Intel Software Developer's Manual 
+[[PDF](http://www.intel.com/Assets/en_US/PDF/manual/253666.pdf)].
+
+Note that, for the naive serial sum, the compiler would
+likely generate similarly efficient code when the
+`-ffast-math` optimization flag is set. By default, the
+compiler is somewhat 'pessimistic' about the set of 
+optimizations it can perform around floating point
+arithmetic. This is because it must respect the
+[IEEE floating point standard](https://en.wikipedia.org/wiki/IEEE_floating_point),
+and this means respecting the fact that, for example,
+floating point operations are not assocative:
+
+{% highlight r %}
+((0.1 + 0.2) + 0.3) - (0.1 + (0.2 + 0.3))
+{% endhighlight %}
+
+
+
+<pre class="output">
+[1] 1.110223e-16
+</pre>
+
+Surprisingly, the above computation does not evaluate to
+zero!
+
+In practice, you're likely safe to take advantage of the
+`-ffast-math` optimizations, or `Boost.SIMD`, in your own
+work. However, be sure to test and verify!
+
+---
+
+This article provides just a taste of how RcppNT2 can be used.
+If you're interested in learning more, please check out the
+[RcppNT2 website](http://rcppcore.github.io/RcppNT2/).

--- a/_posts/2016-02-01-rcppnt2-variance.md
+++ b/_posts/2016-02-01-rcppnt2-variance.md
@@ -1,0 +1,240 @@
+---
+title: Using RcppNT2 to Compute the Variance
+author: Kevin Ushey
+license: GPL (>= 2)
+tags: simd parallel
+summary: Demonstrates how to compute the variance using RcppNT2.
+layout: post
+src: 2016-02-01-rcppnt2-variance.cpp
+---
+
+
+## Introduction
+
+The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+collection of header-only C++ libraries that make it
+possible to explicitly request the use of SIMD instructions
+when possible, while falling back to regular scalar
+operations when not. **NT<sup>2</sup>** itself is powered
+by [Boost](http://www.boost.org/), alongside two proposed
+Boost libraries -- `Boost.Dispatch`, which provides a
+mechanism for efficient tag-based dispatch for functions,
+and `Boost.SIMD`, which provides a framework for the
+implementation of algorithms that take advantage of SIMD
+instructions.
+[`RcppNT2`](http://rcppcore.github.io/RcppNT2/) wraps
+and exposes these libraries for use with `R`.
+
+If you haven't already, read the
+[RcppNT2 introduction article]({{ site.baseurl }}/articles/rcppnt2-introduction/)
+to get acquainted with the RcppNT2 package.
+
+## Computing the Variance
+
+As you may or may not know, there are a number of algorithms
+for [computing the variance](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance),
+each making different tradeoffs in algorithmic complexity
+versus numerical stability. We'll focus on implementing a
+two-pass algorithm, whereby we compute the mean in a first
+pass, and later the sum of squares in a second pass.
+
+First, let's look at the R code one might write
+to compute the variance.
+
+{% highlight r %}
+set.seed(123)
+x <- rnorm(16)
+myVar <- function(x) {
+  sum((x - mean(x))^2) / (length(x) - 1)
+}
+stopifnot(all.equal(var(x), myVar(x)))
+c(var(x), myVar(x))
+{% endhighlight %}
+
+
+
+<pre class="output">
+[1] 0.833939 0.833939
+</pre>
+
+We can decompose the operation into a few distinct steps:
+
+1. Compute the mean for our vector 'x',
+2. Compute the squared deviations from the mean,
+3. Sum the deviations about the mean,
+4. Divide the summation by the length minus one.
+
+Naively, we could imagine writing a 'simdTransform()' for 
+step 2, and an 'simdReduce()' for step 3. However, this 
+is a bit inefficient as the transform would require 
+allocating a whole new vector, with the same length as 
+our initial vector. When neither 'simdTransform()' nor
+'simdReduce()' seem to be a good fit, we can fall back to
+'simdFor()'. We can pass a stateful functor to handle
+accumulation of the transformed results.
+
+Let's write a class that encapsulates this 'sum of
+squares' operation.
+
+{% highlight cpp %}
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+class SumOfSquaresAccumulator
+{
+public:
+   
+   // Since the 'transform()' operation requires knowledge
+   // of the mean, we ensure our class must be constructed
+   // with a mean value. We will also hold the final result
+   // within the 'result_' variable, and a SIMD 'pack_' to
+   // hold the results for SIMD computations.
+   explicit SumOfSquaresAccumulator(double mean)
+      : mean_(mean), result_(0.0), pack_(0.0)
+   {}
+   
+   // We need to provide two call operators: one to handle
+   // SIMD packs, and one to handle scalar values. We do this
+   // as we want to accumulate SIMD results in a SIMD data
+   // structure, and scalar results in a scalar data object.
+   //
+   // We _could_ just accumulate all our results in a single
+   // 'double', but this is actually less efficient -- it
+   // pays to use packed structures when possible.
+   void operator()(double data)
+   {
+      result_ += nt2::sqr(data - mean_);
+   }
+   
+   void operator()(const boost::simd::pack<double>& data)
+   {
+      pack_ += nt2::sqr(data - mean_);
+   }
+   
+   // We can use 'value()' to extract the result of the 
+   // computation, after providing this object to
+   // 'simdFor()'.
+   double value() const
+   {
+      return result_ + boost::simd::sum(pack_);
+   }
+   
+private:
+   double mean_;
+   double result_;
+   boost::simd::pack<double> pack_;
+};
+{% endhighlight %}
+
+Now that we have our accumulator class defined, we can
+use it to compute the variance. We'll call our function
+'simdVar()', and export it using Rcpp attributes in the
+usual way.
+
+{% highlight cpp %}
+// [[Rcpp::export]]
+double simdVar(NumericVector data)
+{
+   using namespace RcppNT2;
+   
+   // First, compute the mean as we'll need that for
+   // computation of the sum of squares.
+   double total = simdReduce(data.begin(), data.end(), 0.0, functor::plus());
+   
+   std::size_t n = data.size();
+   double mean = total / n;
+   
+   // Use our accumulator to compute the sum of squares.
+   SumOfSquaresAccumulator accumulator(mean);
+   simdFor(data.begin(), data.end(), accumulator);
+   double ssq = accumulator.value();
+   
+   // Divide by 'n - 1', and we're done!
+   return ssq / (n - 1);
+}
+{% endhighlight %}
+
+Let's confirm that this works as expected...
+
+{% highlight r %}
+x <- as.numeric(1:10)
+c(var(x), simdVar(x))
+{% endhighlight %}
+
+
+
+<pre class="output">
+[1] 9.166667 9.166667
+</pre>
+
+
+
+{% highlight r %}
+stopifnot(all.equal(var(x), simdVar(x)))
+{% endhighlight %}
+
+And let's benchmark, to see how performance compares.
+
+{% highlight r %}
+library(microbenchmark)
+
+# A helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+small <- as.numeric(1:16)
+stopifnot(all.equal(var(small), simdVar(small)))
+bm <- microbenchmark(var(small), simdVar(small))
+printBm(bm)
+{% endhighlight %}
+
+
+
+<pre class="output">
+           expr    min      lq     mean median      uq    max
+     var(small) 11.784 14.3395 16.37862 15.096 15.7225 40.346
+ simdVar(small)  1.506  1.7045  2.06541  1.947  2.1055 10.935
+</pre>
+
+
+
+{% highlight r %}
+large <- rnorm(1E6)
+stopifnot(all.equal(var(large), simdVar(large)))
+bm <- microbenchmark(var(large), simdVar(large))
+printBm(bm)
+{% endhighlight %}
+
+
+
+<pre class="output">
+           expr      min       lq      mean    median       uq      max
+     var(large) 3046.597 3194.231 3278.7417 3301.6205 3323.581 3809.090
+ simdVar(large)  579.784  594.887  607.0411  607.9845  614.386  712.038
+</pre>
+
+As we can see, taking advantage of SIMD instructions
+has improved the runtime quite drastically.
+
+However, we should note that this is not an entirely fair
+comparison with `R`s implementation of the variance. In
+particular, we do not have a nice mechanism for handling 
+missing values; if your data does have any `NA` or `NaN`
+values, they will simply be propagated (and not
+necessarily in the same way that `R` propagates
+missingness). If you're interested, a separate example
+is provided as part of the RcppNT2 package, and you can
+browse the standalone source file
+[here](https://github.com/RcppCore/RcppNT2/blob/master/inst/examples/example-na-handling-variance.cpp).
+
+---
+
+This article provides just a taste of how RcppNT2 can be used.
+If you're interested in learning more, please check out the
+[RcppNT2 website](http://rcppcore.github.io/RcppNT2/).

--- a/css/styles.css
+++ b/css/styles.css
@@ -30,3 +30,11 @@ h3 {
    float: right;
    margin-bottom: 2em;
 }
+
+p > code {
+   white-space: nowrap;
+}
+
+a > code {
+  color: #4183c4;
+}

--- a/src/2016-01-22-simd-introduction.Rmd
+++ b/src/2016-01-22-simd-introduction.Rmd
@@ -1,0 +1,249 @@
+---
+title: "Introduction to Boost.SIMD"
+author: "Kevin Ushey"
+license: GPL (>= 2)
+tags: simd parallel
+summary: Introduction to Boost.SIMD with RcppParallel
+---
+
+Modern CPU processors are built with new, extended
+instruction sets that optimize for certain operations. A
+class of these allow for vectorized operations, called
+Single Instruction / Multiple Data (SIMD) instructions. 
+Although modern compilers will use these instructions when
+possible, they are often unable to reason about whether or
+not a particular block of code can be executed using SIMD
+instructions.
+
+`Boost.SIMD`
+[[PDF](https://meetingcpp.com/tl_files/mcpp/slides/12/simd.pdf)]
+is a C++ header-only library that makes it possible to
+explicitly request the use of SIMD instructions when
+possible, while falling back to regular scalar operations
+when not.
+[`RcppParallel`](http://rcppcore.github.io/RcppParallel/) 
+wraps and exposes this library for use with `R` vectors.
+
+The primary abstraction that `Boost.SIMD` uses under the 
+hood is the `boost::simd::pack<>` data structure. This item 
+represents a small, contiguous, pack of integral objects 
+(e.g. `double`s), and comes with a host of functions that 
+facilitate the use of SIMD operations on those objects when 
+possible. Although you don't need to know the details to use
+the high-level functionality provided by `Boost.SIMD`, it's
+useful for understanding what happens behind the scenes.
+
+Here's a quick example of how we might compute the sum of 
+elements in a vector, using `Boost.SIMD`.
+
+```{r, engine='Rcpp'}
+// [[Rcpp::depends(RcppParallel)]]
+#define RCPP_PARALLEL_USE_SIMD
+#include <RcppParallel.h>
+using namespace RcppParallel;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// Define a functor -- a C++ class which defines a templated
+// 'function call' operator -- to perform the addition of 
+// two pieces of data.
+struct add_two {
+  template <typename T>
+  T operator()(const T& lhs, const T& rhs) {
+    return lhs + rhs;
+  }
+};
+
+// [[Rcpp::export]]
+double simd_sum(NumericVector x) {
+  // Pass the functor to 'simdReduce()'.
+  return simdReduce(x.begin(), x.end(), 0.0, add_two());
+}
+```
+
+Behind the scenes, `simdReduce()` takes care of iteration 
+over our sequence, and ensures that we use optimized SIMD 
+instructions over packs of numbers when possible, and scalar
+instructions when not. By passing a templated functor, 
+`simdReduce()` can automagically choose the correct template
+specialization depending on whether it's working with a pack
+or not. In other words, two template specializations will be
+generated in this case: one with `T = double`, and another
+with `T = boost::simd::pack<double>`.
+
+Let's confirm that this produces the correct output, and run
+a small benchmark.
+
+```{r}
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# generate some data
+data <- rnorm(1024 * 1000)
+
+# verify that it produces the correct sum
+all.equal(simd_sum(data), sum(data))
+
+# compare results
+library(microbenchmark)
+bm <- microbenchmark(sum(data), simd_sum(data))
+printBm(bm)
+```
+
+We get a noticable gain by taking advantage of SIMD 
+instructions here, although it's worth noting that we don't
+handle `NA` and `NaN` with the same granularity as `R`.
+
+## SIMD Algorithms
+
+`Boost.SIMD` provides two primary abstractions for the
+implementation of SIMD algorithms:
+
+{: .table .table-condensed .table-bordered}
+| Algorithm                   | Transformation       |
+|-----------------------------|----------------------|
+| `boost::simd::transform()`  | `vector` -> `vector` |
+| `boost::simd::accumulate()` | `vector` -> `scalar` |
+
+These functions operate like their `std::` counterparts, but
+expect a functor with a templated call operator. By making
+the call operator templated, `Boost.SIMD` can generate code
+using its own optimized SIMD functions when appropriate, and
+fall back to a default implementation (based on the types
+provided) when not.
+
+`RcppParallel` augments this with its own algorithms as well,
+for consistency with `parallelFor()` and `parallelReduce()`:
+
+{: .table .table-condensed .table-bordered}
+| Algorithm                       | Transformation       |
+|---------------------------------|----------------------|
+| `RcppParallel::simdTransform()` | `vector` -> `vector` |
+| `RcppParallel::simdReduce()`    | `vector` -> `scalar` |
+| `RcppParallel::simdFor()`       | `vector` -> `any`    |
+
+`simdFor()` is useful in particular when neither `transform()`
+nor `accumulate()` seem to be a good fit. An example using it
+to compute the variance for a vector of numbers is showcased
+[here]({{ site.baseurl }}/articles/simd-variance/).
+
+## Writing Boost.SIMD-aware Algorithms
+
+To take advantage of `Boost.SIMD`, you should try to perform
+the following steps:
+
+1. Decompose your problem into separate, vectorizable pieces,
+2. Select an appropriate algorithm provided by `RcppParallel`,
+3. Write templated functors in a `Boost.SIMD`-aware way.
+
+`Boost.SIMD` provides a large number of functions that have
+optimized specializations for packed data structures, while
+falling back to regular operations for scalar data structures.
+These functions can typically be accessed within the `boost::simd`
+namespace. To illustrate, here's an example of a functor that
+computes the square for a set of data, using the `boost::simd::sqr()`
+function:
+
+```{r, engine='Rcpp', eval=FALSE}
+class simd_square {
+template <typename T>
+void operator()(const T& data) {
+  return boost::simd::sqr(data);
+}
+};
+```
+
+A reference guide for other functions provided is available 
+[here](http://nt2.metascale.fr/doc/html/boost_simd_functions_and_operators/reference.html).
+
+## Using SIMD in an R Package
+
+To build an R package that uses `Boost.SIMD`, you need to
+make some modifications to the standard `RcppParallel`
+configuration. Within the `DESCRIPTION` file of your package,
+you need to:
+
+1. Add the **BH** package as a `LinkingTo` dependency, and
+2. Add `C++11` as a `SystemRequirement`.
+
+### Platform Compatibility
+
+`Boost.SIMD` requires a C++11 conformant compiler. This 
+means that packages making use of SIMD features may not 
+compile on platforms with older compilers, including Windows
+and RedHat/CentOS Linux. You can however create a package 
+that takes advantage of `Boost.SIMD` where available and
+falls back to a non-SIMD implementation otherwise.
+
+You can opt-in to the use of `Boost.SIMD` by defining the 
+`RCPP_PARALLEL_USE_SIMD` macro before including 
+`<RcppParallel.h>`, e.g.
+
+    #define RCPP_PARALLEL_USE_SIMD
+    #include <RcppParallel.h>
+    
+You can test for the availability of `Boost.SIMD` on a given
+platform using the `RCPP_PARALLEL_USE_SIMD` preprocessor
+variable. If the current compiler doesn't support C++11 (as
+determined by `__cplusplus <= 199711L`) the variable will be
+undefined (even if you defined it explicitly). This allows
+you to write code like this:
+
+```{r, engine='Rcpp', eval=FALSE}
+#define RCPP_PARALLEL_USE_SIMD
+#include <RcppParallel.h>
+
+#if RCPP_PARALLEL_USE_SIMD
+
+IntegerVector transformDataImpl(IntegerVector x) {
+  // Implement with Boost.SIMD
+}
+
+#else
+
+IntegerVector transformDataImpl(IntegerVector x) {
+  // Implement without Boost.SIMD
+}
+
+#endif
+
+// [[Rcpp::export]]
+IntegerVector transformData(IntegerVector x) {
+   return transformDataImpl(x);
+}
+```
+
+The two `transformDataImpl` functions have the same name,
+but only one will be compiled and linked based on whether
+the target platform supports `Boost.SIMD`.
+
+Note that if you conditionally compile all uses of 
+`Boost.SIMD` within your package, then you can drop the
+`C++11` from `SystemRequirements` (it's no longer required
+as a result of your fallback implementation).
+
+## Learning More
+
+If you want to dive deeper into `Boost.SIMD`, you can
+[read the online documentation](http://nt2.metascale.fr/doc/html/boost_simd.html),
+and also browse the examples
+[here](https://github.com/RcppCore/RcppParallel/tree/master/inst/examples/boost-simd).
+
+---
+
+If you want to try out `Boost.SIMD` yourself, please 
+install the development version of 
+[`RcppParallel`](http://rcppcore.github.io/RcppParallel/)
+with `devtools::install_github("RcppCore/RcppParallel")`.
+
+
+   
+
+
+
+
+

--- a/src/2016-01-22-simd-sum.cpp
+++ b/src/2016-01-22-simd-sum.cpp
@@ -1,0 +1,174 @@
+/**
+ * @title Using Boost.SIMD to Compute the Sum
+ * @author Kevin Ushey
+ * @license GPL (>= 2)
+ * @tags simd parallel
+ * @summary Demonstrates how to compute the sum using Boost.SIMD.
+ */
+
+/**
+ * The latest development version of
+ * [RcppParallel](http://rcppcore.github.io/RcppParallel/) 
+ * now bundles the
+ * [Boost.SIMD](https://www.lri.fr/~falcou/pub/pact-2012.pdf)
+ * library, providing a framework for ensuring that the
+ * algorithms you write take advantage of the vectorized
+ * instructions offered by new CPUs. This article
+ * illustrates how you might use `Boost.SIMD` to sum all of
+ * the elements in a vector, using the `simdReduce()` 
+ * function.
+ */
+
+/**
+ * If you haven't already, please see
+ * [this article]({{ site.baseurl }}/articles/simd-introduction/) for an
+ * introduction to `Boost.SIMD`, and how to use it with `RcppParallel`.
+ */
+
+/**
+ * First, let's review how we might use `std::accumulate()`
+ * to sum a vector of numbers. We explicitly pass in the
+ * `std::plus<double>()` functor, just to make it clear that
+ * the `std::accumulate()` algorithm expects a binary
+ * functor when accumulating values.
+ */
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+double vectorSum(NumericVector x) {
+   return std::accumulate(x.begin(), x.end(), 0.0, std::plus<double>());
+}
+
+/**
+ * Now, let's rewrite this to take advantage of
+ * `Boost.SIMD`. There are two main steps required to take
+ * advantage of `Boost.SIMD` at a high level:
+ * 
+ *   1. Write a functor, with a templated call operator,
+ *      with the implementation written in a
+ *      '`Boost.SIMD`-aware' way;
+ * 
+ *   2. Provide the functor as an argument to the
+ *      appropriate SIMD algorithm.
+ * 
+ * Let's follow these steps in implementing our SIMD sum.
+ */
+
+// [[Rcpp::depends(RcppParallel)]]
+
+// Because the Boost.SIMD headers are quite heavy-weight,
+// we must explicitly opt-in to using the SIMD headers
+#define RCPP_PARALLEL_USE_SIMD
+#include <RcppParallel.h>
+using namespace RcppParallel;
+
+struct simd_plus {
+   template <typename T>
+   T operator()(const T& lhs, const T& rhs) {
+      return lhs + rhs;
+   }
+};
+
+// [[Rcpp::export]]
+double vectorSumSimd(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, simd_plus());
+}
+
+/**
+ * As you can see, it's quite simple to take advantage of
+ * `Boost.SIMD`. For very simple operations such as this,
+ * `RcppParallel` provides a number of pre-defined functors,
+ * which can be accessed in the `RcppParallel::simd_ops`
+ * namespace. The following is an equivalent way of defining
+ * the above function:
+ */
+
+// [[Rcpp::export]]
+double vectorSumSimdV2(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, simd_ops::plus());
+}
+
+/**
+ * Behind the scenes of `simdReduce()`, `Boost.SIMD` will 
+ * apply your templated functor to 'packs' of values when
+ * appropriate, and scalar values when not. In other words,
+ * there are effectively two kinds of template
+ * specializations being generated behind the scenes: one
+ * with `T = double`, and one with `T =
+ * boost::simd::pack<double>`. The use of the packed
+ * representation is what allows `Boost.SIMD` to ensure 
+ * vectorized instructions are used and generated.
+ * `Boost.SIMD` provides a host of functions and operator
+ * overloads that ensure that optimized instructions are
+ * used when possible over a packed object, while falling 
+ * back to 'default' operations for scalar values when not.
+ *
+ * Now, let's compare the performance of these two
+ * implementations.
+ */
+
+/*** R
+library(microbenchmark)
+
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# allocate a large vector
+set.seed(123)
+v <- rnorm(1E6)
+
+# ensure they compute the same values
+stopifnot(all.equal(vectorSum(v), vectorSumSimd(v)))
+
+# compare performance
+bm <- microbenchmark(vectorSum(v), vectorSumSimd(v))
+printBm(bm)
+*/
+
+/**
+ * Perhaps surprisingly, the `Boost.SIMD` solution is much
+ * faster -- the gains are similar to what we might have
+ * seen when computing the sum in parallel. However, we're
+ * still just using a single core; we're just taking
+ * advantage of vectorized instructions provided by the CPU.
+ * In this particular case, on Intel CPUs, `Boost.SIMD` will
+ * ensure that we are using the `addpd` instruction, which
+ * is documented in the Intel Software Developer's Manual 
+ * [[PDF](http://www.intel.com/Assets/en_US/PDF/manual/253666.pdf)].
+ * 
+ * Note that, for the naive serial sum, the compiler would
+ * likely generate similarly efficient code when the
+ * `-ffast-math` optimization flag is set. By default, the
+ * compiler is somewhat 'pessimistic' about the set of 
+ * optimizations it can perform around floating point
+ * arithmetic. This is because it must respect the
+ * [IEEE floating point standard](https://en.wikipedia.org/wiki/IEEE_floating_point),
+ * and this means respecting the fact that, for example,
+ * floating point operations are not assocative:
+ */
+
+/*** R
+((0.1 + 0.2) + 0.3) - (0.1 + (0.2 + 0.3))
+*/
+
+/**
+ * Surprisingly, the above computation does not evaluate to
+ * zero!
+ * 
+ * In practice, you're likely safe to take advantage of the
+ * `-ffast-math` optimizations, or `Boost.SIMD`, in your own
+ * work. However, be sure to test and verify!
+ * 
+ * ---
+ * 
+ * If you want to try out `Boost.SIMD` yourself, please 
+ * install the development version of 
+ * [`RcppParallel`](http://rcppcore.github.io/RcppParallel/)
+ * with `devtools::install_github("RcppCore/RcppParallel")`.
+ */
+

--- a/src/2016-01-22-simd-variance.cpp
+++ b/src/2016-01-22-simd-variance.cpp
@@ -1,0 +1,197 @@
+/**
+ * @title Using Boost.SIMD to Compute the Variance
+ * @author Kevin Ushey
+ * @license GPL (>= 2)
+ * @tags simd parallel
+ * @summary Demonstrates how to compute the variance using Boost.SIMD.
+ */
+
+/**
+ * This article illustrates how we might take advantage of
+ * `Boost.SIMD` in computing the variance for a vector of
+ * numbers.
+ */
+
+/**
+ * If you haven't already, please see
+ * [this article]({{ site.baseurl }}/articles/simd-introduction/) for an
+ * introduction to `Boost.SIMD`, and how to use it with `RcppParallel`.
+ */
+
+/** 
+ * As you may or may not know, there are a number of algorithms
+ * for [computing the variance](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance),
+ * each making different tradeoffs in algorithmic complexity
+ * versus numerical stability. We'll focus on implementing a
+ * two-pass algorithm, whereby we compute the mean in a first
+ * pass, and later the sum of squares in a second pass.
+ * 
+ * First, let's look at the R code one might write
+ * to compute the variance.
+ */
+
+/*** R
+set.seed(123)
+x <- rnorm(16)
+myVar <- function(x) {
+  sum((x - mean(x))^2) / (length(x) - 1)
+}
+stopifnot(all.equal(var(x), myVar(x)))
+c(var(x), myVar(x))
+*/
+
+/**
+ * We can decompose the operation into a few distinct steps:
+ * 
+ *    1. Compute the mean for our vector 'x',
+ *    2. Compute the squared deviations from the mean,
+ *    3. Sum the deviations about the mean,
+ *    4. Divide the summation by the length minus one.
+ * 
+ * Naively, we could imagine writing a 'simdTransform()' for 
+ * step 2, and an 'simdReduce()' for step 3. However, this 
+ * is a bit inefficient as the transform would require 
+ * allocating a whole new vector, with the same length as 
+ * our initial vector. When neither 'simdTransform()' nor
+ * 'simdReduce()' seem to be a good fit, we can fall back to
+ * 'simdFor()'. We can pass a stateful functor to handle
+ * accumulation of the transformed results.
+ * 
+ * Let's write a class that encapsulates this 'sum of
+ * squares' operation.
+ */
+
+// [[Rcpp::depends(RcppParallel)]]
+#define RCPP_PARALLEL_USE_SIMD
+#include <RcppParallel.h>
+using namespace RcppParallel;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+class SumOfSquaresAccumulator
+{
+public:
+   
+   // Since the 'transform()' operation requires knowledge
+   // of the mean, we ensure our class must be constructed
+   // with a mean value. We will also hold the final result
+   // within the 'result_' variable, and a SIMD 'pack_' to
+   // hold the results for SIMD computations.
+   explicit SumOfSquaresAccumulator(double mean)
+      : mean_(mean), result_(0.0), pack_(0.0)
+   {}
+   
+   // We need to provide two call operators: one to handle
+   // SIMD packs, and one to handle scalar values. We do this
+   // as we want to accumulate SIMD results in a SIMD data
+   // structure, and scalar results in a scalar data object.
+   //
+   // We _could_ just accumulate all our results in a single
+   // 'double', but this is actually less efficient -- it
+   // pays to use packed structures when possible.
+   void operator()(double data)
+   {
+      result_ += boost::simd::sqr(data - mean_);
+   }
+   
+   void operator()(const boost::simd::pack<double>& data)
+   {
+      pack_ += boost::simd::sqr(data - mean_);
+   }
+   
+   // We can use 'value()' to extract the result of the 
+   // computation, after providing this object to
+   // 'simdFor()'.
+   double value() const
+   {
+      return result_ + boost::simd::sum(pack_);
+   }
+   
+private:
+   double mean_;
+   double result_;
+   boost::simd::pack<double> pack_;
+};
+
+/**
+ * Now that we have our accumulator class defined, we can
+ * use it to compute the variance. We'll call our function
+ * 'simdVar()', and export it using Rcpp attributes in the
+ * usual way.
+ */
+
+// [[Rcpp::export]]
+double simdVar(NumericVector data)
+{
+   using namespace RcppParallel;
+   
+   // First, compute the mean as we'll need that for
+   // computation of the sum of squares.
+   double total = simdReduce(data.begin(), data.end(), 0.0, simd_ops::plus());
+   
+   std::size_t n = data.size();
+   double mean = total / n;
+   
+   // Use our accumulator to compute the sum of squares.
+   SumOfSquaresAccumulator accumulator(mean);
+   simdFor(data.begin(), data.end(), accumulator);
+   double ssq = accumulator.value();
+   
+   // Divide by 'n - 1', and we're done!
+   return ssq / (n - 1);
+}
+
+/**
+ * Let's confirm that this works as expected...
+ */
+
+/*** R
+x <- as.numeric(1:10)
+c(var(x), simdVar(x))
+stopifnot(all.equal(var(x), simdVar(x)))
+*/
+
+/**
+ * And let's benchmark, to see how performance compares.
+ */
+
+/*** R
+library(microbenchmark)
+
+# A helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+small <- as.numeric(1:16)
+stopifnot(all.equal(var(small), simdVar(small)))
+bm <- microbenchmark(var(small), simdVar(small))
+printBm(bm)
+
+large <- rnorm(1E6)
+stopifnot(all.equal(var(large), simdVar(large)))
+bm <- microbenchmark(var(large), simdVar(large))
+printBm(bm)
+*/
+
+/**
+ * As we can see, taking advantage of SIMD instructions
+ * has improved the runtime quite drastically.
+ * 
+ * However, we should note that this is not an entirely fair
+ * comparison with `R`s implementation of the variance. In
+ * particular, we do not have a nice mechanism for handling 
+ * missing values; if your data does have any `NA` or `NaN`
+ * values, they will simply be propagated (and not
+ * necessarily in the same way that `R` propagates
+ * missingness).
+ * 
+ * ---
+ * 
+ * If you want to try out `Boost.SIMD` yourself, please 
+ * install the development version of 
+ * [`RcppParallel`](http://rcppcore.github.io/RcppParallel/)
+ * with `devtools::install_github("RcppCore/RcppParallel")`.
+ */

--- a/src/2016-02-01-rcppnt2-introduction.Rmd
+++ b/src/2016-02-01-rcppnt2-introduction.Rmd
@@ -1,0 +1,112 @@
+---
+title: "Introduction to RcppNT2"
+author: "Kevin Ushey"
+license: GPL (>= 2)
+tags: simd parallel
+summary: Introduction to RcppNT2
+---
+
+Modern CPU processors are built with new, extended
+instruction sets that optimize for certain operations. A
+class of these allow for vectorized operations, called
+Single Instruction / Multiple Data
+([SIMD](https://en.wikipedia.org/wiki/SIMD)) instructions. 
+Although modern compilers will use these instructions when
+possible, they are often unable to reason about whether or
+not a particular block of code can be executed using SIMD
+instructions.
+
+The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+is a collection of header-only C++ libraries that make it 
+possible to explicitly request the use of SIMD instructions 
+when possible, while falling back to regular scalar
+operations when not. **NT<sup>2</sup>** itself is powered
+by [Boost](http://www.boost.org/), alongside two proposed
+Boost libraries -- `Boost.Dispatch`, which provides a
+mechanism for efficient tag-based dispatch for functions,
+and `Boost.SIMD`, which provides a framework for the
+implementation of algorithms that take advantage of SIMD
+instructions. [RcppNT2](http://rcppcore.github.io/RcppNT2/)
+wraps and exposes these libraries for use with `R`.
+
+The primary abstraction that `Boost.SIMD` uses under the 
+hood is the `boost::simd::pack<>` data structure. This item 
+represents a small, contiguous, pack of integral objects 
+(e.g. `double`s), and comes with a host of functions that 
+facilitate the use of SIMD operations on those objects when 
+possible. Although you don't need to know the details to use
+the high-level functionality provided by `Boost.SIMD`, it's
+useful for understanding what happens behind the scenes.
+
+Here's a quick example of how we might compute the sum of 
+elements in a vector, using **NT<sup>2</sup>**.
+
+```{r, engine='Rcpp'}
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// Define a functor -- a C++ class which defines a templated
+// 'function call' operator -- to perform the addition of 
+// two pieces of data.
+struct add_two {
+  template <typename T>
+  T operator()(const T& lhs, const T& rhs) {
+    return lhs + rhs;
+  }
+};
+
+// [[Rcpp::export]]
+double simd_sum(NumericVector x) {
+  // Pass the functor to 'simdReduce()'. This is an
+  // algorithm provided by RcppNT2, which makes it
+  // easy to apply nt2-style functor definitions
+  // across a range of data.
+  return simdReduce(x.begin(), x.end(), 0.0, add_two());
+}
+```
+
+Behind the scenes, `simdReduce()` takes care of iteration 
+over the provided sequence, and ensures that we use optimized SIMD 
+instructions over packs of numbers when possible, and scalar
+instructions when not. By passing a templated functor, 
+`simdReduce()` can automatically choose the correct template
+specialization depending on whether it's working with a pack
+or not. In other words, two template specializations will be
+generated in this case: one with `T = double`, and another
+with `T = boost::simd::pack<double>`.
+
+Let's confirm that this produces the correct output, and run
+a small benchmark.
+
+```{r}
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# generate some data
+data <- rnorm(1024 * 1000)
+
+# verify that it produces the correct sum
+all.equal(simd_sum(data), sum(data))
+
+# compare results
+library(microbenchmark)
+bm <- microbenchmark(sum(data), simd_sum(data))
+printBm(bm)
+```
+
+We get a noticable gain by taking advantage of SIMD 
+instructions here. However, it's worth noting that we don't
+handle `NA` and `NaN` with the same granularity as `R`.
+
+## Learning More
+
+This article provides just a taste of how RcppNT2 can be used.
+If you're interested in learning more, please check out the
+[RcppNT2 website](http://rcppcore.github.io/RcppNT2/).

--- a/src/2016-02-01-rcppnt2-sum.cpp
+++ b/src/2016-02-01-rcppnt2-sum.cpp
@@ -1,0 +1,173 @@
+/**
+ * @title Using RcppNT2 to Compute the Sum
+ * @author Kevin Ushey
+ * @license GPL (>= 2)
+ * @tags simd parallel
+ * @summary Demonstrates how to compute the sum using RcppNT2.
+ */
+
+/**
+ * ## Introduction
+ * 
+ * The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+ * collection of header-only C++ libraries that make it
+ * possible to explicitly request the use of SIMD instructions
+ * when possible, while falling back to regular scalar
+ * operations when not. **NT<sup>2</sup>** itself is powered
+ * by [Boost](http://www.boost.org/), alongside two proposed
+ * Boost libraries -- `Boost.Dispatch`, which provides a
+ * mechanism for efficient tag-based dispatch for functions,
+ * and `Boost.SIMD`, which provides a framework for the
+ * implementation of algorithms that take advantage of SIMD
+ * instructions.
+ * [`RcppNT2`](http://rcppcore.github.io/RcppNT2/) wraps
+ * and exposes these libraries for use with `R`.
+ * 
+ * If you haven't already, read the
+ * [RcppNT2 introduction article]({{ site.baseurl }}/articles/rcppnt2-introduction/)
+ * to get acquainted with the RcppNT2 package.
+ */
+
+/**
+ * ## Computing the Sum
+ * 
+ * First, let's review how we might use `std::accumulate()`
+ * to sum a vector of numbers. We explicitly pass in the
+ * `std::plus<double>()` functor, just to make it clear that
+ * the `std::accumulate()` algorithm expects a binary
+ * functor when accumulating values.
+ */
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+// [[Rcpp::export]]
+double vectorSum(NumericVector x) {
+   return std::accumulate(x.begin(), x.end(), 0.0, std::plus<double>());
+}
+
+/**
+ * Now, let's rewrite this to take advantage of RcppNT2.
+ * There are two main steps required to take advantage of
+ * RcppNT2 at a high level:
+ * 
+ *   1. Write a functor, with a templated call operator,
+ *      with the implementation written in a
+ *      '`Boost.SIMD`-aware' way;
+ * 
+ *   2. Provide the functor as an argument to the
+ *      appropriate SIMD algorithm.
+ * 
+ * Let's follow these steps in implementing our SIMD sum.
+ */
+
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+struct simd_plus {
+   template <typename T>
+   T operator()(const T& lhs, const T& rhs) {
+      return lhs + rhs;
+   }
+};
+
+// [[Rcpp::export]]
+double vectorSumSimd(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, simd_plus());
+}
+
+/**
+ * As you can see, it's quite simple to take advantage of
+ * `Boost.SIMD`. For very simple operations such as this,
+ * RcppNT2 provides a number of pre-defined functors,
+ * which can be accessed in the `RcppParallel::functor`
+ * namespace. The following is an equivalent way of defining
+ * the above function:
+ */
+
+// [[Rcpp::export]]
+double vectorSumSimdV2(NumericVector x) {
+   return simdReduce(x.begin(), x.end(), 0.0, functor::plus());
+}
+
+/**
+ * Behind the scenes of `simdReduce()`, `Boost.SIMD` will 
+ * apply your templated functor to 'packs' of values when
+ * appropriate, and scalar values when not. In other words,
+ * there are effectively two kinds of template
+ * specializations being generated behind the scenes: one
+ * with `T = double`, and one with `T =
+ * boost::simd::pack<double>`. The use of the packed
+ * representation is what allows `Boost.SIMD` to ensure 
+ * vectorized instructions are used and generated.
+ * `Boost.SIMD` provides a host of functions and operator
+ * overloads that ensure that optimized instructions are
+ * used when possible over a packed object, while falling 
+ * back to 'default' operations for scalar values when not.
+ *
+ * Now, let's compare the performance of these two
+ * implementations.
+ */
+
+/*** R
+library(microbenchmark)
+
+# helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+# allocate a large vector
+set.seed(123)
+v <- rnorm(1E6)
+
+# ensure they compute the same values
+stopifnot(all.equal(vectorSum(v), vectorSumSimd(v)))
+
+# compare performance
+bm <- microbenchmark(vectorSum(v), vectorSumSimd(v))
+printBm(bm)
+*/
+
+/**
+ * Perhaps surprisingly, the RcppNT2 solution is much
+ * faster -- the gains are similar to what we might have
+ * seen when computing the sum in parallel. However, we're
+ * still just using a single core; we're just taking
+ * advantage of vectorized instructions provided by the CPU.
+ * In this particular case, on Intel CPUs, `Boost.SIMD` will
+ * ensure that we are using the `addpd` instruction, which
+ * is documented in the Intel Software Developer's Manual 
+ * [[PDF](http://www.intel.com/Assets/en_US/PDF/manual/253666.pdf)].
+ * 
+ * Note that, for the naive serial sum, the compiler would
+ * likely generate similarly efficient code when the
+ * `-ffast-math` optimization flag is set. By default, the
+ * compiler is somewhat 'pessimistic' about the set of 
+ * optimizations it can perform around floating point
+ * arithmetic. This is because it must respect the
+ * [IEEE floating point standard](https://en.wikipedia.org/wiki/IEEE_floating_point),
+ * and this means respecting the fact that, for example,
+ * floating point operations are not assocative:
+ */
+
+/*** R
+((0.1 + 0.2) + 0.3) - (0.1 + (0.2 + 0.3))
+*/
+
+/**
+ * Surprisingly, the above computation does not evaluate to
+ * zero!
+ * 
+ * In practice, you're likely safe to take advantage of the
+ * `-ffast-math` optimizations, or `Boost.SIMD`, in your own
+ * work. However, be sure to test and verify!
+ * 
+ * ---
+ * 
+ * This article provides just a taste of how RcppNT2 can be used.
+ * If you're interested in learning more, please check out the
+ * [RcppNT2 website](http://rcppcore.github.io/RcppNT2/).
+ */

--- a/src/2016-02-01-rcppnt2-variance.cpp
+++ b/src/2016-02-01-rcppnt2-variance.cpp
@@ -1,0 +1,210 @@
+/**
+ * @title Using RcppNT2 to Compute the Variance
+ * @author Kevin Ushey
+ * @license GPL (>= 2)
+ * @tags simd parallel
+ * @summary Demonstrates how to compute the variance using RcppNT2.
+ */
+
+/**
+ * ## Introduction
+ * 
+ * The [Numerical Template Toolbox (**NT<sup>2</sup>**)](https://github.com/jfalcou/nt2)
+ * collection of header-only C++ libraries that make it
+ * possible to explicitly request the use of SIMD instructions
+ * when possible, while falling back to regular scalar
+ * operations when not. **NT<sup>2</sup>** itself is powered
+ * by [Boost](http://www.boost.org/), alongside two proposed
+ * Boost libraries -- `Boost.Dispatch`, which provides a
+ * mechanism for efficient tag-based dispatch for functions,
+ * and `Boost.SIMD`, which provides a framework for the
+ * implementation of algorithms that take advantage of SIMD
+ * instructions.
+ * [`RcppNT2`](http://rcppcore.github.io/RcppNT2/) wraps
+ * and exposes these libraries for use with `R`.
+ * 
+ * If you haven't already, read the
+ * [RcppNT2 introduction article]({{ site.baseurl }}/articles/rcppnt2-introduction/)
+ * to get acquainted with the RcppNT2 package.
+ */
+
+/** 
+ * ## Computing the Variance
+ * 
+ * As you may or may not know, there are a number of algorithms
+ * for [computing the variance](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance),
+ * each making different tradeoffs in algorithmic complexity
+ * versus numerical stability. We'll focus on implementing a
+ * two-pass algorithm, whereby we compute the mean in a first
+ * pass, and later the sum of squares in a second pass.
+ * 
+ * First, let's look at the R code one might write
+ * to compute the variance.
+ */
+
+/*** R
+set.seed(123)
+x <- rnorm(16)
+myVar <- function(x) {
+  sum((x - mean(x))^2) / (length(x) - 1)
+}
+stopifnot(all.equal(var(x), myVar(x)))
+c(var(x), myVar(x))
+*/
+
+/**
+ * We can decompose the operation into a few distinct steps:
+ * 
+ *    1. Compute the mean for our vector 'x',
+ *    2. Compute the squared deviations from the mean,
+ *    3. Sum the deviations about the mean,
+ *    4. Divide the summation by the length minus one.
+ * 
+ * Naively, we could imagine writing a 'simdTransform()' for 
+ * step 2, and an 'simdReduce()' for step 3. However, this 
+ * is a bit inefficient as the transform would require 
+ * allocating a whole new vector, with the same length as 
+ * our initial vector. When neither 'simdTransform()' nor
+ * 'simdReduce()' seem to be a good fit, we can fall back to
+ * 'simdFor()'. We can pass a stateful functor to handle
+ * accumulation of the transformed results.
+ * 
+ * Let's write a class that encapsulates this 'sum of
+ * squares' operation.
+ */
+
+// [[Rcpp::depends(RcppNT2)]]
+#include <RcppNT2.h>
+using namespace RcppNT2;
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+class SumOfSquaresAccumulator
+{
+public:
+   
+   // Since the 'transform()' operation requires knowledge
+   // of the mean, we ensure our class must be constructed
+   // with a mean value. We will also hold the final result
+   // within the 'result_' variable, and a SIMD 'pack_' to
+   // hold the results for SIMD computations.
+   explicit SumOfSquaresAccumulator(double mean)
+      : mean_(mean), result_(0.0), pack_(0.0)
+   {}
+   
+   // We need to provide two call operators: one to handle
+   // SIMD packs, and one to handle scalar values. We do this
+   // as we want to accumulate SIMD results in a SIMD data
+   // structure, and scalar results in a scalar data object.
+   //
+   // We _could_ just accumulate all our results in a single
+   // 'double', but this is actually less efficient -- it
+   // pays to use packed structures when possible.
+   void operator()(double data)
+   {
+      result_ += nt2::sqr(data - mean_);
+   }
+   
+   void operator()(const boost::simd::pack<double>& data)
+   {
+      pack_ += nt2::sqr(data - mean_);
+   }
+   
+   // We can use 'value()' to extract the result of the 
+   // computation, after providing this object to
+   // 'simdFor()'.
+   double value() const
+   {
+      return result_ + boost::simd::sum(pack_);
+   }
+   
+private:
+   double mean_;
+   double result_;
+   boost::simd::pack<double> pack_;
+};
+
+/**
+ * Now that we have our accumulator class defined, we can
+ * use it to compute the variance. We'll call our function
+ * 'simdVar()', and export it using Rcpp attributes in the
+ * usual way.
+ */
+
+// [[Rcpp::export]]
+double simdVar(NumericVector data)
+{
+   using namespace RcppNT2;
+   
+   // First, compute the mean as we'll need that for
+   // computation of the sum of squares.
+   double total = simdReduce(data.begin(), data.end(), 0.0, functor::plus());
+   
+   std::size_t n = data.size();
+   double mean = total / n;
+   
+   // Use our accumulator to compute the sum of squares.
+   SumOfSquaresAccumulator accumulator(mean);
+   simdFor(data.begin(), data.end(), accumulator);
+   double ssq = accumulator.value();
+   
+   // Divide by 'n - 1', and we're done!
+   return ssq / (n - 1);
+}
+
+/**
+ * Let's confirm that this works as expected...
+ */
+
+/*** R
+x <- as.numeric(1:10)
+c(var(x), simdVar(x))
+stopifnot(all.equal(var(x), simdVar(x)))
+*/
+
+/**
+ * And let's benchmark, to see how performance compares.
+ */
+
+/*** R
+library(microbenchmark)
+
+# A helper function for printing microbenchmark output
+printBm <- function(bm) {
+  summary <- summary(bm)
+  print(summary[, 1:7], row.names = FALSE)
+}
+
+small <- as.numeric(1:16)
+stopifnot(all.equal(var(small), simdVar(small)))
+bm <- microbenchmark(var(small), simdVar(small))
+printBm(bm)
+
+large <- rnorm(1E6)
+stopifnot(all.equal(var(large), simdVar(large)))
+bm <- microbenchmark(var(large), simdVar(large))
+printBm(bm)
+*/
+
+/**
+ * As we can see, taking advantage of SIMD instructions
+ * has improved the runtime quite drastically.
+ * 
+ * However, we should note that this is not an entirely fair
+ * comparison with `R`s implementation of the variance. In
+ * particular, we do not have a nice mechanism for handling 
+ * missing values; if your data does have any `NA` or `NaN`
+ * values, they will simply be propagated (and not
+ * necessarily in the same way that `R` propagates
+ * missingness). If you're interested, a separate example
+ * is provided as part of the RcppNT2 package, and you can
+ * browse the standalone source file
+ * [here](https://github.com/RcppCore/RcppNT2/blob/master/inst/examples/example-na-handling-variance.cpp).
+ * 
+ * ---
+ * 
+ * This article provides just a taste of how RcppNT2 can be used.
+ * If you're interested in learning more, please check out the
+ * [RcppNT2 website](http://rcppcore.github.io/RcppNT2/).
+ */

--- a/staging/.gitignore
+++ b/staging/.gitignore
@@ -1,0 +1,5 @@
+*
+
+!.gitignore
+!Makefile
+

--- a/staging/Makefile
+++ b/staging/Makefile
@@ -1,0 +1,21 @@
+KNIT = ../_scripts/knit.sh
+POSTS_DIR = ../_posts
+CPP_FILES := $(wildcard *.cpp)
+RMD_FILES := $(wildcard *.Rmd)
+MD_FILES := $(patsubst %.cpp, $(POSTS_DIR)/%.md, ${CPP_FILES}) \
+            $(patsubst %.Rmd, $(POSTS_DIR)/%.md, ${RMD_FILES})
+
+all: $(MD_FILES)
+	
+$(POSTS_DIR)/%.md: %.cpp
+	cp "$<" "../src/$<"
+	$(KNIT) $< $@
+
+$(POSTS_DIR)/%.md: %.Rmd
+	cp "$<" "../src/$<"
+	$(KNIT) $< $@
+
+.PHONY: clean
+clean:
+	$(RM) ${MD_FILES}
+

--- a/tags/simd/index.html
+++ b/tags/simd/index.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: simd
+---
+
+{% include tag_page.html %}


### PR DESCRIPTION
This PR adds two articles, showcasing how `Boost.SIMD` (now part of the development version of `RcppParallel`) can be used.

@jjallaire, can you review?

(Aside -- is there a simple way of building only a subset of gallery articles?)
