### PR TITLE
Fix data race in the example

### DIFF
--- a/src/2013-05-16-using-rcppprogress.Rmd
+++ b/src/2013-05-16-using-rcppprogress.Rmd
@@ -170,14 +170,14 @@ Now check that it is parallelized:
 // [[Rcpp::depends(RcppProgress)]]
 #include <progress.hpp>
 // [[Rcpp::export]]
-double long_computation_omp2(int nb, int threads=1) {
+double long_computation_omp2(const int nb, int threads=1) {
 #ifdef _OPENMP
     if ( threads > 0 )
         omp_set_num_threads( threads );
 #endif
     Progress p(nb, true);
     double sum = 0;
-#pragma omp parallel for schedule(dynamic)   
+#pragma omp parallel for default(none) reduction(+ : sum) schedule(dynamic)
     for (int i = 0; i < nb; ++i) {
         double thread_sum = 0;
         if ( ! Progress::check_abort() ) {


### PR DESCRIPTION
We have a data race on the shared variable `sum` (involving unsynchronized modification `+=`) in `long_computation_omp2`.
Fix:
- `default(none)` - prevents inadvertent data races (`nb` was another potential one when not `const`; adjusted)
- `reduction(+ : sum)` - treats `sum` as a reduction variable (with proper synchronization)