### PR TITLE
Update mathjax to v3 (closes #137)

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -67,18 +67,18 @@
 
     {% if page.mathjax == true %}
     <!-- MathJax Support -->
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-      tex2jax: {
-      inlineMath: [],
-      displayMath: []
+    <script>
+    MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+      },
+      svg: {
+        fontCache: 'global'
       }
-      }) ;
+    };
     </script>
-    <script
-       type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-       >
+    <script type="text/javascript" id="MathJax-script" async
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
     </script>
     {% endif %}
 


### PR DESCRIPTION
This PR fixes inline rendering which currently does not work (though we still have full 'displaymath' equation support).